### PR TITLE
Fix a typo in pyipmi.__init__.py to report errors correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ using the `ipmitool`_ as backend.
     import pyipmi
     import pyipmi.interfaces
     
-    interface = pyipmi.interfaces.create_interface('ipmitool')
+    interface = pyipmi.interfaces.create_interface('ipmitool', interface_type='lanplus')
     
     connection = pyipmi.create_connection(interface)
 

--- a/pyipmi/interfaces/ipmitool.py
+++ b/pyipmi/interfaces/ipmitool.py
@@ -33,12 +33,14 @@ class Ipmitool:
 
     NAME = 'ipmitool'
     IPMITOOL_PATH = 'ipmitool'
+    INTERFACE_TYPE = 'lan'
 
-    def __init__(self):
+    def __init__(self, interface_type='lan'):
         self.re_completion_code = re.compile(
                 "Unable to send RAW command \(.*rsp=(0x[0-9a-f]+)\)")
         self.re_timeout = re.compile(
                 "Unable to send RAW command \(.*cmd=0x[0-9a-f]+\)")
+        self.INTERFACE_TYPE = interface_type
 
     def establish_session(self, session):
         # just remember session parameters here
@@ -47,7 +49,7 @@ class Ipmitool:
     def rmcp_ping(self):
         # for now this uses impitool..
         cmd = self.IPMITOOL_PATH
-        cmd += (' -I lan')
+        cmd += (' -I %s' % self.INTERFACE_TYPE)
         cmd += (' -H %s' % self._session._rmcp_host)
         cmd += (' -p %s' % self._session._rmcp_port)
         if self._session.auth_type == Session.AUTH_TYPE_NONE:
@@ -129,7 +131,7 @@ class Ipmitool:
             raise RuntimeError('Session needs to be set')
 
         cmd = self.IPMITOOL_PATH
-        cmd += (' -I lan')
+        cmd += (' -I %s' % self.INTERFACE_TYPE)
         cmd += (' -H %s' % self._session._rmcp_host)
         cmd += (' -p %s' % self._session._rmcp_port)
 


### PR DESCRIPTION
if an error happened I wont be reported as this type will give another error 