### PR TITLE
Fix setup.py in python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except (OSError, subprocess.CalledProcessError, IOError) as e:
     try:
         with open(version_py, 'r') as f:
             d = dict()
-            exec(f, d)
+            exec(f.read(), d)
             version = d['__version__']
     except IOError:
         version = 'unknown'


### PR DESCRIPTION
Fixed setup.py in python 3 if git fails and fallback version getter is used.

Does nothing to comply with pep 440 for version formatting.