### PR TITLE
Update to Python 3.9

### DIFF
--- a/pyipmi/fields.py
+++ b/pyipmi/fields.py
@@ -5,6 +5,7 @@
 import array
 
 from .errors import DecodingError
+from .utils import py3_array_tobytes
 
 
 class VersionField(object):
@@ -38,10 +39,10 @@ class VersionField(object):
         """`data` is array.array"""
         self.major = data[0]
 
-        if data[1] is 0xff:
+        if data[1] == 0xff:
             self.minor = data[1]
         elif data[1] <= 0x99:
-            self.minor = int(data[1:2].tostring().decode('bcd+'))
+            self.minor = int(py3_array_tobytes(data[1:2]).decode('bcd+'))
         else:
             raise DecodingError()
 

--- a/pyipmi/hpm.py
+++ b/pyipmi/hpm.py
@@ -29,7 +29,7 @@ from .errors import CompletionCodeError, HpmError, IpmiTimeoutError
 from .msgs import create_request_by_name
 from .msgs import constants
 from .utils import check_completion_code, bcd_search, chunks
-from .utils import py3dec_unic_bytes_fix, bytes2 as bytes
+from .utils import py3dec_unic_bytes_fix, bytes2 as bytes, py3_array_tobytes
 from .state import State
 from .fields import VersionField
 
@@ -203,7 +203,7 @@ class Hpm(object):
             try:
                 status = self.get_upgrade_status()
                 if status.command_in_progress is not expected_cmd \
-                        and status.command_in_progress is not 0x34:
+                        and status.command_in_progress != 0x34:
                     pass
                 if status.last_completion_code \
                         == CC_LONG_DURATION_CMD_IN_PROGRESS:
@@ -474,9 +474,11 @@ class ComponentPropertyCurrentVersion(ComponentProperty):
 class ComponentPropertyDescriptionString(ComponentProperty):
 
     def _from_rsp_data(self, data):
-        self.description = py3dec_unic_bytes_fix(array('B', data).tostring())
+        descr = py3_array_tobytes(array('B', data))
+        descr = py3dec_unic_bytes_fix(descr)
         # strip '\x00'
-        self.description = self.description.replace('\0', '')
+        descr = descr.replace('\0', '')
+        self.description = descr
 
 
 class ComponentPropertyRollbackVersion(ComponentProperty):

--- a/pyipmi/interfaces/ipmb.py
+++ b/pyipmi/interfaces/ipmb.py
@@ -20,6 +20,7 @@ from ..logger import log
 from ..msgs import (create_message, create_request_by_name,
                     encode_message, decode_message, constants)
 from ..utils import check_completion_code
+from ..utils import py3_array_tobytes, py3_array_frombytes
 
 
 def checksum(data):
@@ -62,7 +63,7 @@ class IpmbHeaderReq(IpmbHeader):
         data.append(self.rq_sa)
         data.append(self.rq_seq << 2 | self.rq_lun)
         data.append(self.cmd_id)
-        return data.tostring()
+        return py3_array_tobytes(data)
 
     def decode(self):
         raise NotImplementedError()
@@ -93,14 +94,13 @@ def encode_ipmb_msg(header, data):
     Returns the message as bytestring.
     """
     msg = array('B')
-
-    msg.fromstring(header.encode())
+    py3_array_frombytes(msg, header.encode())
     if data is not None:
         a = array('B')
-        a.fromstring(data)
+        py3_array_frombytes(a, data)
         msg.extend(a)
     msg.append(checksum(msg[3:]))
-    return msg.tostring()
+    return py3_array_tobytes(msg)
 
 
 def encode_send_message(payload, rq_sa, rs_sa, channel, seq, tracking=1):

--- a/pyipmi/interfaces/ipmitool.py
+++ b/pyipmi/interfaces/ipmitool.py
@@ -25,7 +25,7 @@ from ..errors import IpmiTimeoutError
 from ..logger import log
 from ..msgs import encode_message, decode_message, create_message
 from ..msgs.constants import CC_OK
-from ..utils import py3dec_unic_bytes_fix, ByteBuffer
+from ..utils import py3dec_unic_bytes_fix, ByteBuffer, py3_array_tobytes
 
 
 class Ipmitool(object):
@@ -49,9 +49,9 @@ class Ipmitool(object):
                                interface_type)
 
         self.re_completion_code = re.compile(
-                b"Unable to send RAW command \(.*rsp=(0x[0-9a-f]+)\)")
+                br"Unable to send RAW command \(.*rsp=(0x[0-9a-f]+)\)")
         self.re_timeout = re.compile(
-                b"Unable to send RAW command \(.*cmd=0x[0-9a-f]+\)")
+                br"Unable to send RAW command \(.*cmd=0x[0-9a-f]+\)")
 
         self._session = None
 
@@ -135,7 +135,7 @@ class Ipmitool(object):
         log().debug('IPMI RX: {:s}'.format(
             ''.join('%02x ' % b for b in array('B', data))))
 
-        return data.tostring()
+        return py3_array_tobytes(data)
 
     def send_and_receive(self, req):
         log().debug('IPMI Request [%s]', req)
@@ -144,7 +144,7 @@ class Ipmitool(object):
         req_data.push_string(encode_message(req))
 
         rsp_data = self.send_and_receive_raw(req.target, req.lun, req.netfn,
-                                             req_data.tostring())
+                                             py3_array_tobytes(req_data))
 
         rsp = create_message(req.netfn + 1, req.cmdid, req.group_extension)
         decode_message(rsp, rsp_data)

--- a/pyipmi/interfaces/rmcp.py
+++ b/pyipmi/interfaces/rmcp.py
@@ -32,7 +32,7 @@ from ..logger import log
 from ..interfaces.ipmb import (IpmbHeaderReq, encode_ipmb_msg,
                                encode_bridged_message, decode_bridged_message,
                                rx_filter)
-from ..utils import check_completion_code
+from ..utils import check_completion_code, py3_array_tobytes
 
 
 CLASS_NORMAL_MSG = 0x00
@@ -262,7 +262,7 @@ class IpmiMsg(object):
         else:
             raise NotSupportedError('authentication type %s' % auth_type)
 
-        pdu += array('B', [data_len]).tostring()
+        pdu += py3_array_tobytes(array('B', [data_len]))
 
         if sdu is not None:
             pdu += sdu

--- a/pyipmi/lan.py
+++ b/pyipmi/lan.py
@@ -58,7 +58,7 @@ class Lan(object):
                              revision_only=0):
         req = create_request_by_name('GetLanConfigurationParameters')
         req.command.get_parameter_revision_only = revision_only
-        if revision_only is not 1:
+        if revision_only != 1:
             req.command.channel_number = channel
             req.parameter_selector = parameter_selector
             req.set_selector = set_selector

--- a/pyipmi/sdr.py
+++ b/pyipmi/sdr.py
@@ -374,13 +374,13 @@ class SdrFullSensorRecord(SdrCommon):
         elif capabilities & THRESHOLD_MASK == THRESHOLD_IS_FIXED:
             self.capabilities.append('threshold_fixed')
         # sensor event message control support
-        if (capabilities & 0x03) is 0:
+        if (capabilities & 0x03) == 0:
             pass
-        if (capabilities & 0x03) is 1:
+        if (capabilities & 0x03) == 1:
             pass
-        if (capabilities & 0x03) is 2:
+        if (capabilities & 0x03) == 2:
             pass
-        if (capabilities & 0x03) is 3:
+        if (capabilities & 0x03) == 3:
             pass
 
     def _from_data(self, data):

--- a/tests/interfaces/test_rmcp.py
+++ b/tests/interfaces/test_rmcp.py
@@ -10,6 +10,7 @@ from pyipmi import Target
 from pyipmi.session import Session
 from pyipmi.interfaces.rmcp import (AsfMsg, AsfPing, AsfPong, IpmiMsg,
                                     Rmcp, RmcpMsg)
+from pyipmi.utils import py3_array_tobytes
 
 
 class TestRmcpMsg:
@@ -83,7 +84,7 @@ class TestIpmiMsg:
         eq_(psw, b'admin\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 
     def test_ipmimsg_pack_with_data(self):
-        data = array.array('B', (1, 2, 3, 4)).tostring()
+        data = py3_array_tobytes(array.array('B', (1, 2, 3, 4)))
         m = IpmiMsg()
         pdu = m.pack(data)
         eq_(pdu, b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x02\x03\x04')


### PR DESCRIPTION
* Fix SyntaxWarning: "is not" with a literal. Did you mean "!="?
* Add py3_array_frombytes() and py3_array_tobytes() to pyipmi.utils.
  frombytes() and tostring() methods of array.array have been removed
  from Python 3.9.
* Python 3.9 normalizes the encoding name "bcd+" to "bcd".
* Replace b'...' with br'...' in two regular expressions.
* Add _PY3 private constant to pyipmi.utils.