### PR TITLE
Skip FRU test cases if FRU test file is missing

### DIFF
--- a/tests/test_fru.py
+++ b/tests/test_fru.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
+import nose
 from nose.tools import eq_
 
 from pyipmi.fru import (FruData, InventoryCommonHeader,
@@ -29,6 +30,8 @@ def test_commonheader_object():
 def test_fru_inventory_from_file():
     path = os.path.dirname(os.path.abspath(__file__))
     fru_file = os.path.join(path, 'fru_bin/kontron_am4010.bin')
+    if not os.path.isfile(fru_file):
+        raise nose.SkipTest("FRU file '%s' is missing." % (fru_file))
     fru = get_fru_inventory_from_file(fru_file)
     eq_(fru.chassis_info_area, None)
 
@@ -36,6 +39,8 @@ def test_fru_inventory_from_file():
 def test_board_area():
     path = os.path.dirname(os.path.abspath(__file__))
     fru_file = os.path.join(path, 'fru_bin/kontron_am4010.bin')
+    if not os.path.isfile(fru_file):
+        raise nose.SkipTest("FRU file '%s' is missing." % (fru_file))
     fru = get_fru_inventory_from_file(fru_file)
 
     board_area = fru.board_info_area
@@ -48,6 +53,8 @@ def test_board_area():
 def test_product_area():
     path = os.path.dirname(os.path.abspath(__file__))
     fru_file = os.path.join(path, 'fru_bin/kontron_am4010.bin')
+    if not os.path.isfile(fru_file):
+        raise nose.SkipTest("FRU file '%s' is missing." % (fru_file))
     fru = get_fru_inventory_from_file(fru_file)
 
     product_area = fru.product_info_area

--- a/tests/test_hpm.py
+++ b/tests/test_hpm.py
@@ -3,6 +3,7 @@
 
 import os
 
+import nose
 from nose.tools import eq_, ok_
 
 from pyipmi.hpm import (ComponentProperty, ComponentPropertyDescriptionString,
@@ -91,6 +92,8 @@ def test_upgradeactionrecord_create_from_data():
 def test_upgrade_image():
     path = os.path.dirname(os.path.abspath(__file__))
     hpm_file = os.path.join(path, 'hpm_bin/firmware.hpm')
+    if not os.path.isfile(hpm_file):
+        raise nose.SkipTest("HPM binary file '%s' is missing." % (hpm_file))
     image = UpgradeImage(hpm_file)
     ok_(isinstance(image.actions[0], UpgradeActionRecordPrepare))
     ok_(isinstance(image.actions[1], UpgradeActionRecordUploadForUpgrade))


### PR DESCRIPTION
The release tarball does not contain `tests/hpm_bin/firmware.hpm` and `tests/fru_bin/kontron_am4010.bin`.