### PR TITLE
Fix SyntaxWarning: "is" with a literal. Did you mean "=="?

### DIFF
--- a/pyipmi/ipmitool.py
+++ b/pyipmi/ipmitool.py
@@ -361,7 +361,7 @@ def cmd_picmg_get_portstate_all(ipmi, args):
                 (p, s) = ipmi.get_port_state(channel, interface)
                 print_link_state(p, s)
             except pyipmi.errors.CompletionCodeError as e:
-                if e.cc is 0xcc:
+                if e.cc == 0xcc:
                     continue
 
 


### PR DESCRIPTION
Commit aca3528d1f1b8ed88e54cbbf2fbfaa0621985224 fixed most syntax warnings, but missed one.