### PR TITLE
Fix AttributeError: 'ByteBuffer' object has no attribute 'tobytes'

### DIFF
--- a/pyipmi/utils.py
+++ b/pyipmi/utils.py
@@ -110,6 +110,9 @@ class ByteBuffer(object):
         self.__delslice__(0, length)
         return c
 
+    def tobytes(self):
+        return self.array.tobytes()
+
     def tostring(self):
         return py3_array_tobytes(self.array)
 


### PR DESCRIPTION
Following Python code fails:

```python
interface = pyipmi.interfaces.create_interface(interface='ipmitool', interface_type='lanplus')
ipmi = pyipmi.create_connection(interface)
ipmi.session.set_session_type_rmcp(host=fqdn, port=port)
ipmi.session.set_auth_type_user(username=username, password=password)
ipmi.target = pyipmi.Target()
ipmi.session.establish()
ipmi_info = ipmi.get_device_id()
```

```
Traceback (most recent call last):
  File "example.py", line 7
    ipmi_info = ipmi.get_device_id()
  File "pyipmi/bmc.py", line 25, in get_device_id
    return DeviceId(self.send_message_with_name('GetDeviceId'))
  File "pyipmi/__init__.py", line 206, in send_message_with_name
    rsp = self.send_message(req)
  File "pyipmi/__init__.py", line 190, in send_message
    rsp = self.interface.send_and_receive(req)
  File "pyipmi/interfaces/ipmitool.py", line 147, in send_and_receive
    py3_array_tobytes(req_data))
  File "pyipmi/utils.py", line 57, in py3_array_tobytes
    return msg.tobytes()
AttributeError: 'ByteBuffer' object has no attribute 'tobytes'
```

Add a `ByteBuffer.tobytes` method. `ByteBuffer.tobytes` will only be called if Python's array.array has a `tobytes` method. Therefore the helper `py3_array_tobytes` is not needed.

Fixes https://github.com/kontron/python-ipmi/issues/80