### PR TITLE
Make ipmitool interface robust against prepended error messages

### DIFF
--- a/pyipmi/interfaces/ipmitool.py
+++ b/pyipmi/interfaces/ipmitool.py
@@ -123,10 +123,8 @@ class Ipmitool(object):
             output = py3dec_unic_bytes_fix(output)
 
             output_lines = output.split('\n')
-            # strip 'Close Session command failed' lines
-            output_lines = [l for l in output_lines
-                            if not l.startswith(
-                                'Close Session command failed')]
+            # strip any error messages
+            output_lines = [l for l in output_lines if 'failed' not in l]
             output = ''.join(output_lines).replace('\r', '').strip()
             if len(output):
                 for value in output.split(' '):

--- a/tests/interfaces/test_ipmitool.py
+++ b/tests/interfaces/test_ipmitool.py
@@ -7,6 +7,7 @@ from nose.tools import eq_, raises
 from pyipmi.errors import IpmiTimeoutError
 from pyipmi.interfaces import Ipmitool
 from pyipmi import Session, Target
+from pyipmi.utils import py3_array_tobytes
 
 
 class TestIpmitool:
@@ -150,3 +151,29 @@ class TestIpmitool:
         mock.assert_called_once_with('ipmitool -I serial-terminal '
                                      '-D /dev/tty2:115200 -t 0x20 -l 0 '
                                      'raw 0x06 0x01')
+
+    def test_parse_output_rsp(self):
+        test_str = b' 12 34 56 78 \r\n d0 0f af fe de ad be ef\naa 55\r\nbb    \n'
+        cc, rsp = self._interface._parse_output(test_str)
+        eq_(cc, None)
+        eq_(py3_array_tobytes(rsp), b'\x12\x34\x56\x78\xd0\x0f\xaf\xfe\xde\xad\xbe\xef\xaa\x55\xbb')
+
+    def test_parse_output_rsp_suppressed_error(self):
+        test_str = b'Get HPM.x Capabilities request failed, compcode = c9\n'\
+                   b' 12 34 56 78 \r\n d0 0f af fe de ad be ef\naa 55\r\nbb    \n'
+        cc, rsp = self._interface._parse_output(test_str)
+        eq_(cc, None)
+        eq_(py3_array_tobytes(rsp), b'\x12\x34\x56\x78\xd0\x0f\xaf\xfe\xde\xad\xbe\xef\xaa\x55\xbb')
+
+    def test_parse_output_cc(self):
+        test_str = b'Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xcc): Ignore Me\n'
+        cc, rsp = self._interface._parse_output(test_str)
+        eq_(cc, 0xcc)
+        eq_(rsp, None)
+
+    def test_parse_output_cc_suppressed_error(self):
+        test_str = b'Get HPM.x Capabilities request failed, compcode = c9\n'\
+                   b'Unable to send RAW command (channel=0x0 netfn=0x6 lun=0x0 cmd=0x1 rsp=0xcc): Ignore Me\n'
+        cc, rsp = self._interface._parse_output(test_str)
+        eq_(cc, 0xcc)
+        eq_(rsp, None)


### PR DESCRIPTION
I got a use case where ipmitool doesn't fail, but prepends the raw data with a error message line, probably due to a MicroTCA MCH failing a capabilities request. The requested IPMI access as such does succeed and data is printed out.
example:
```
$ ipmitool -I lan -H 192.168.1.209 -A NONE -T 0x82 -B 0 -t 0x7a -b 7 raw 0x30 0xf0 0x00
Get HPM.x Capabilities request failed, compcode = c9
 4d 4d 43 20 43 6f 6e 73 6f 6c 65
```
`pyipmi.interfaces.ipmitool.send_and_receive_raw()` tries to parse the error message as hex dump (see below)

This patch throws out all error message lines (those that contain the word 'failed') to make sure ipmitool's hex output is still parsed.

```
Running ipmitool "ipmitool -I lan -H 192.168.1.209 -p 623 -U "" -P "" -T 0x82 -B 0 -t 0x7a -b 7 -l 0 raw 0x30 0xf0 0x00 2>&1"
return with rc=0, output was:
b'Get HPM.x Capabilities request failed, compcode = c9\n 4d 4d 43 20 43 6f 6e 73 6f 6c 65\n'
Traceback (most recent call last):
  File "~/src/python-ipmi/pyipmi/__init__.py", line 220, in raw_command
    raw_bytes)
  File "~/src/python-ipmi/pyipmi/interfaces/ipmitool.py", line 133, in send_and_receive_raw
    data.append(int(value, 16))
ValueError: invalid literal for int() with base 16: 'Get'
```