### PR TITLE
Add SdrUnknownSensorRecord to allow fully iterating a SDR repository

### DIFF
--- a/pyipmi/sdr.py
+++ b/pyipmi/sdr.py
@@ -227,23 +227,20 @@ class SdrCommon(object):
     def from_data(data, next_id=None):
         sdr_type = data[3]
 
-        try:
-            cls = {
-                SDR_TYPE_FULL_SENSOR_RECORD:
-                    SdrFullSensorRecord,
-                SDR_TYPE_COMPACT_SENSOR_RECORD:
-                    SdrCompactSensorRecord,
-                SDR_TYPE_EVENT_ONLY_SENSOR_RECORD:
-                    SdrEventOnlySensorRecord,
-                SDR_TYPE_FRU_DEVICE_LOCATOR_RECORD:
-                    SdrFruDeviceLocator,
-                SDR_TYPE_MANAGEMENT_CONTROLLER_DEVICE_LOCATOR_RECORD:
-                    SdrManagementControllerDeviceLocator,
-                SDR_TYPE_OEM_SENSOR_RECORD:
-                    SdrOEMSensorRecord,
-            }[sdr_type]
-        except KeyError:
-            raise DecodingError('Unsupported SDR type(0x%02x)' % sdr_type)
+        cls = {
+            SDR_TYPE_FULL_SENSOR_RECORD:
+                SdrFullSensorRecord,
+            SDR_TYPE_COMPACT_SENSOR_RECORD:
+                SdrCompactSensorRecord,
+            SDR_TYPE_EVENT_ONLY_SENSOR_RECORD:
+                SdrEventOnlySensorRecord,
+            SDR_TYPE_FRU_DEVICE_LOCATOR_RECORD:
+                SdrFruDeviceLocator,
+            SDR_TYPE_MANAGEMENT_CONTROLLER_DEVICE_LOCATOR_RECORD:
+                SdrManagementControllerDeviceLocator,
+            SDR_TYPE_OEM_SENSOR_RECORD:
+                SdrOEMSensorRecord,
+        }.get(sdr_type, SdrUnknownSensorRecord)
 
         return cls(data, next_id)
 
@@ -627,3 +624,12 @@ class SdrOEMSensorRecord(SdrCommon):
 
         # record key bytes
         self._common_record_key(buffer.pop_slice(3))
+
+
+# Any SDR type not known or not implemented
+class SdrUnknownSensorRecord(SdrCommon):
+    def __init__(self, data=None, next_id=None):
+        super(SdrUnknownSensorRecord, self).__init__(data, next_id)
+
+    def __str__(self):
+        return 'Not supported yet.'

--- a/tests/test_sdr.py
+++ b/tests/test_sdr.py
@@ -6,7 +6,8 @@ from nose.tools import eq_, ok_, raises
 from pyipmi.errors import DecodingError
 from pyipmi.sdr import (SdrCommon, SdrFullSensorRecord, SdrCompactSensorRecord,
                         SdrEventOnlySensorRecord, SdrFruDeviceLocator,
-                        SdrManagementControllerDeviceLocator)
+                        SdrManagementControllerDeviceLocator,
+                        SdrUnknownSensorRecord)
 
 
 class TestSdrFullSensorRecord():
@@ -237,3 +238,9 @@ class TestSdrManagementControllerDeviceRecord():
                 0x30, 0x20]
         sdr = SdrManagementControllerDeviceLocator(data)
         eq_(sdr.device_id_string, b'A2:AM4220 ')
+
+
+def test_unknown_record_type():
+    data = [0x01, 0x0, 0x51, 0x0a, 0x0]
+    sdr = SdrCommon.from_data(data, 0xffff)
+    ok_(isinstance(sdr, SdrUnknownSensorRecord))


### PR DESCRIPTION
As discussed in https://github.com/kontron/python-ipmi/issues/99, this change will allow `sdr_repository_entries()` to finish iterating when an unknown record is found. 