### PR TITLE
minor fixes

### DIFF
--- a/pyipmi/interfaces/rmcp.py
+++ b/pyipmi/interfaces/rmcp.py
@@ -545,7 +545,7 @@ class Rmcp(object):
         header.rq_seq = self.next_sequence_number
         header.rq_lun = 0
         header.rq_sa = self.slave_address
-        header.cmd_id = cmdid
+        header.cmdid = cmdid
 
         # Bridge message
         if target.routing:

--- a/pyipmi/ipmitool.py
+++ b/pyipmi/ipmitool.py
@@ -361,7 +361,7 @@ def cmd_picmg_get_portstate_all(ipmi, args):
                 (p, s) = ipmi.get_port_state(channel, interface)
                 print_link_state(p, s)
             except pyipmi.errors.CompletionCodeError as e:
-                if e.cc is 0xcc:
+                if e.cc == 0xcc:
                     continue
 
 

--- a/pyipmi/picmg.py
+++ b/pyipmi/picmg.py
@@ -235,7 +235,7 @@ class LinkDescriptor(State):
     STATE_ENABLE = picmg.LINK_STATE_ENABLE
 
     __properties__ = [
-        # (propery, description)
+        # (property, description)
         ('channel', ''),
         ('interface', ''),
         ('link_flags', ''),
@@ -339,7 +339,7 @@ class LedState(State):
     FUNCTION_LAMP_TEST = 4
 
     __properties__ = [
-        # (propery, description)
+        # (property, description)
         ('fru_id', ''),
         ('led_id', ''),
         ('local_state_available', ''),
@@ -450,7 +450,7 @@ class LedState(State):
 
 class GlobalStatus(State):
     __properties__ = [
-        # (propery, description)
+        # (property, description)
         ('role', ''),
         ('management_power_good', ''),
         ('payload_power_good', ''),
@@ -469,7 +469,7 @@ class GlobalStatus(State):
 
 class PowerChannelStatus(State):
     __properties__ = [
-        # (propery, description)
+        # (property, description)
         ('present', ''),
         ('management_power', ''),
         ('management_power_overcurrent', ''),


### PR DESCRIPTION
 - cmd_id was renamed in the last commit - but not in rmcp.py
 - 'is' is to compare instances, '==' should be used to compare values
 - 'propery' -> 'property' in comments