### PR TITLE
interfaces.ipmitool: Throw exception if ipmitool not found

### DIFF
--- a/pyipmi/interfaces/ipmitool.py
+++ b/pyipmi/interfaces/ipmitool.py
@@ -273,4 +273,7 @@ class Ipmitool(object):
                     child.returncode,
                     output)
 
+        if child.returncode == 127:
+            raise RuntimeError('ipmitool command not found')
+
         return output, child.returncode


### PR DESCRIPTION
pyipmi throws confusing error messages when ipmitool interface is used but ipmitool is not installed on the system,
example:
```
  File "/home/jan/.local/lib/python3.8/site-packages/pyipmi/__init__.py", line 225, in raw_command
    return self.interface.send_and_receive_raw(self.target, lun, netfn,
  File "/home/jan/.local/lib/python3.8/site-packages/pyipmi/interfaces/ipmitool.py", line 143, in send_and_receive_raw
    cc, rsp = self._parse_output(output)
  File "/home/jan/.local/lib/python3.8/site-packages/pyipmi/interfaces/ipmitool.py", line 124, in _parse_output
    rsp = array('B', [
  File "/home/jan/.local/lib/python3.8/site-packages/pyipmi/interfaces/ipmitool.py", line 125, in <listcomp>
    int(value, 16) for value in hexstr.split(' ')
```

This patch checks the returncode of the shell invoking ipmitool for 127 (error code for 'command not found') and throws an exception with a clear error message.

(BTW, do we really need `shell=True` in `_run_ipmitool()`? If it can be omitted maybe it could improve performance).