### PR TITLE
Added Handeling for 'target is None' ipmitool.py

### DIFF
--- a/pyipmi/interfaces/ipmitool.py
+++ b/pyipmi/interfaces/ipmitool.py
@@ -184,6 +184,9 @@ class Ipmitool(object):
     @staticmethod
     def _build_ipmitool_target(target):
         cmd = ''
+        if target is None:
+            return ''
+        
         if target.routing is not None:
             # we have to do bridging here
             if len(target.routing) == 1:


### PR DESCRIPTION
For my purposes, I don't need anything related to target to have the library working. I'm using a very old motherboard (Supermicro X9SCM, the latest firmware is from 2010) and want to access its BMC.

The command I want to use is precisely:

`ipmitool -I lan -H 192.168.1.31 -U user -P password chassis status` 

However I was unable to 'assemble' this command with the library in it's current form. The Library always rose an Error:

`    if target.routing is not None:
AttributeError: 'NoneType' object has no attribute 'routing'`

This is my solution to fixing this problem. If there is a solution with the current code that I was unable to find, please indicate to me and discard this pull request.