### PR TITLE
interface.rmcp: allow SEND_MESSAGE answer to arrive in the next packet

### DIFF
--- a/pyipmi/interfaces/rmcp.py
+++ b/pyipmi/interfaces/rmcp.py
@@ -566,6 +566,9 @@ class Rmcp(object):
 
                 if array('B', rx_data)[5] == constants.CMDID_SEND_MESSAGE:
                     rx_data = decode_bridged_message(rx_data)
+                    if not rx_data:
+                        # the forwarded reply is expected in the next packet
+                        continue
 
                 received = rx_filter(header, rx_data)
 


### PR DESCRIPTION
The first reply acknowledges reception of the SEND_MESSAGE request from the
bridge, while the second one contains the forwarded reply

Signed-off-by: Emilio Perez <emilio.perez-juarez@diamond.ac.uk>