### PR TITLE
ipmitool.py: fix issue with printing SDR type 0x13

### DIFF
--- a/pyipmi/ipmitool.py
+++ b/pyipmi/ipmitool.py
@@ -196,8 +196,9 @@ def cmd_sdr_list(ipmi, args):
                 (value, states) = ipmi.get_sensor_reading(s.number)
                 number = s.number
 
-            print_sdr_list_entry(s.id, number, s.device_id_string,
-                                 value, states)
+            id_string = getattr(s, 'device_id_string', None)
+
+            print_sdr_list_entry(s.id, number, id_string, value, states)
 
         except pyipmi.errors.CompletionCodeError as e:
             if s.type in (pyipmi.sdr.SDR_TYPE_COMPACT_SENSOR_RECORD,


### PR DESCRIPTION
SDR type 0x13 has no field device_id_string and will throw an exception. Avoid this by setting device_id_string to 'None' in that case.

Signed-off-by: Heiko Thiery <heiko.thiery@gmail.com>