### PR TITLE
Support SystemBootOptions commands and add boot/lan helpers methods

### DIFF
--- a/pyipmi/lan.py
+++ b/pyipmi/lan.py
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 from .msgs import create_request_by_name
-from .utils import check_completion_code
+from .utils import check_completion_code, ByteBuffer
 
 LAN_PARAMETER_SET_IN_PROGRESS = 0
 LAN_PARAMETER_AUTHENTICATION_TYPE_SUPPORT = 1
@@ -51,6 +51,105 @@ LAN_PARAMETER_IP_ADDRESS_SOURCE_DHCP = 2
 LAN_PARAMETER_IP_ADDRESS_SOURCE_BIOS_OR_SYSTEM_SOFTWARE = 3
 LAN_PARAMETER_IP_ADDRESS_SOURCE_BMC_OTHER_PROTOCOL = 4
 
+CONVERT_RAW_TO_IP_SRC = {
+    0: "unknown",
+    1: "static",
+    2: "dhcp",
+    3: "bios",
+    4: "other"
+}
+
+
+def data_to_ip_address(data):
+    """
+    Convert a `GetLanConfigurationParameters(LAN_PARAMETER_IP_ADDRESS)` response
+    data into the string representation of the encoded ip address,
+    in format xxx.xxx.xxx.xxx .
+    """
+    return '.'.join(map(str, data))
+
+def ip_address_to_data(ip_address):
+    """
+    Convert an ip address (string) into a
+    `SetLanConfigurationParameters(LAN_PARAMETER_IP_ADDRESS)` request data.
+    """
+    return ByteBuffer(map(int, ip_address.split('.')))
+
+def data_to_ip_source(data):
+    """
+    Convert a `GetLanConfigurationParameters(LAN_PARAMETER_IP_ADDRESS_SOURCE)`
+    response data into the string representation of the encoded ip source.
+    """
+    # The ip source is encoded in the last 4 bits of the response
+    return CONVERT_RAW_TO_IP_SRC[data[0] & 0b1111]
+
+def ip_source_to_data(ip_source):
+    """
+    Convert an ip source (string) into a
+    `SetLanConfigurationParameters(LAN_PARAMETER_IP_ADDRESS_SOURCE)` request data.
+    """
+    if ip_source == "dhcp":
+        data = ByteBuffer([2])
+    elif ip_source == "static":
+        data = ByteBuffer([1])
+    else:
+        raise ValueError(f"Unknown value for ip_source argument: {ip_source}. Possible values are: dhcp, static.")
+    return data
+
+def data_to_mac_address(data):
+    """
+    Convert a `GetLanConfigurationParameters(LAN_PARAMETER_MAC_ADDRESS)` response
+    data into the string representation of the encoded mac address,
+    in format aa:bb:cc:dd:ee:ff .
+    """
+    return ':'.join([f"{i:02x}" for i in data])
+
+def data_to_vlan(data):
+    """
+    Convert a `GetLanConfigurationParameters(LAN_PARAMETER_802_1Q_VLAN_ID)` response
+    data into an integer representation of the encoded vlan.
+    """
+    # The vlan ID must be extracted from the response, according to IPMI
+    # specification.
+    #
+    #   Example with VLAN ID = 394
+    #   The raw response to `get_lan_config_param` will be [138, 129]
+    #   The binary representation will be :
+    #
+    #       |    data[0]   |  |    data[1]   |
+    # Rsp : 1 0 0 0  1 0 1 0  1 0 0 0  0 0 0 1
+    #       ^              ^           ^     ^
+    #       |--------------|           |-----|
+    #       |least sign. bits          |most sign. bits
+    #
+    # By rearranging the bits order, we get the VLAN value :
+    #       0 0 0 0  0 0 0 1  1 0 0 0  1 0 1 0 = 394
+    return ((data[1] & 0b1111) << 8) | data[0]
+
+def vlan_to_data(vlan):
+    """
+    Convert a vlan (int) into a
+    `SetLanConfigurationParameters(LAN_PARAMETER_802_1Q_VLAN_ID)` request data.
+    """
+    if not isinstance(vlan, int):
+        raise TypeError(f"Wrong type for vlan argument: {type(vlan)}, expected int.")
+    elif vlan > 4095:
+        raise ValueError(f"Wrong value for vlan argument: {vlan}. It cannot be greater than 4095.")
+
+    if vlan == 0:
+        # We want to deactivate the vlan (no vlan)
+        data = ByteBuffer([0, 0])
+    else:
+        # We want to set the vlan ID
+        # first separate the two bytes of the vlan
+        least_sign_byte = vlan & 0b11111111
+        most_sign_byte = (vlan >> 8) & 0b1111
+        # then create the vlan enabled bit
+        vlan_enable = 0b10000000
+        # finally we concatenate every byte together
+        data = ByteBuffer([least_sign_byte, vlan_enable | most_sign_byte])
+    return data
+
 
 class Lan(object):
     def get_lan_config_param(self, channel=0, parameter_selector=0,
@@ -75,6 +174,72 @@ class Lan(object):
         req.data = data
         rsp = self.send_message(req)
         check_completion_code(rsp.completion_code)
+
+    def get_ip_address(self, channel=0):
+        """
+        Return a string representing the ip address of the device, in format xxx.xxx.xxx.xxx
+        """
+        ip_address_raw = self.get_lan_config_param(channel, LAN_PARAMETER_IP_ADDRESS)
+        return data_to_ip_address(ip_address_raw)
+
+    def set_ip_address(self, ip_address, channel=0):
+        """
+        WARNING: changing the IP address of the BMC will make a current
+        lan session unusable because it still has the former IP address.
+
+        Be sure to open a new session with the new IP for future calls if
+        using a lan interface.
+        """
+        data = ip_address_to_data(ip_address)
+        self.set_lan_config_param(channel, LAN_PARAMETER_IP_ADDRESS, data)
+
+    def get_ip_source(self, channel=0):
+        """
+        Return a string representing the ip source of the device.
+
+        Possible values are listed in `CONVERT_RAW_TO_IP_SRC` variable.
+        """
+        ip_source_raw = self.get_lan_config_param(channel, LAN_PARAMETER_IP_ADDRESS_SOURCE)
+        return data_to_ip_source(ip_source_raw)
+
+    def set_ip_source(self, ip_source, channel=0):
+        """
+        WARNING: changing the IP source may change the IP address of the BMC,
+        which will make a current lan session unusable because it still has
+        the former IP address.
+
+        Be sure to open a new session with the new IP for future calls if
+        using a lan interface.
+        """
+        data = ip_source_to_data(ip_source)
+        self.set_lan_config_param(channel, LAN_PARAMETER_IP_ADDRESS_SOURCE, data)
+
+    def get_mac_address(self, channel=0):
+        """
+        Return a string representing the mac address of the device, in format aa:bb:cc:dd:ee:ff.
+        """
+        mac_address_raw = self.get_lan_config_param(channel, LAN_PARAMETER_MAC_ADDRESS)
+        return data_to_mac_address(mac_address_raw)
+
+    def get_vlan_id(self, channel=0):
+        """
+        Return the 802.1q VLAN ID of the device.
+        """
+        vlan_id_raw = self.get_lan_config_param(channel, LAN_PARAMETER_802_1Q_VLAN_ID)
+        return data_to_vlan(vlan_id_raw)
+
+    def set_vlan_id(self, vlan, channel=0):
+        """
+        WARNING: changing the VLAN ID may change the IP address of the BMC
+        depending on your current network configuration.
+        This could make a current lan session unusable because it still has
+        the former IP address.
+
+        Be sure to open a new session with the new IP for future calls if
+        using a lan interface.
+        """
+        data = vlan_to_data(vlan)
+        self.set_lan_config_param(channel, LAN_PARAMETER_802_1Q_VLAN_ID, data)
 
 
 class LanParameter(object):

--- a/pyipmi/msgs/chassis.py
+++ b/pyipmi/msgs/chassis.py
@@ -23,6 +23,7 @@ from . import UnsignedInt
 from . import Bitfield
 from . import CompletionCode
 from . import Optional
+from . import RemainingBytes
 
 CONTROL_POWER_DOWN = 0
 CONTROL_POWER_UP = 1
@@ -135,4 +136,50 @@ class GetPohCounterRsp(Message):
         CompletionCode(),
         UnsignedInt('minutes_per_count', 1),
         UnsignedInt('counter_reading', 4),
+    )
+
+@register_message_class
+class GetSystemBootOptionsReq(Message):
+    __cmdid__ = constants.CMDID_GET_SYSTEM_BOOT_OPTIONS
+    __netfn__ = constants.NETFN_CHASSIS
+    __fields__ = (
+        Bitfield('parameter_selector', 1,
+                 Bitfield.Bit('boot_option_parameter_selector', 7),
+                 Bitfield.ReservedBit(1)),
+        UnsignedInt('set_selector', 1, 0),
+        UnsignedInt('block_selector', 1, 0)
+    )
+
+@register_message_class
+class GetSystemBootOptionsRsp(Message):
+    __cmdid__ = constants.CMDID_GET_SYSTEM_BOOT_OPTIONS
+    __netfn__ = constants.NETFN_CHASSIS | 1
+    __fields__ = (
+        CompletionCode(),
+        Bitfield('parameter_version', 1,
+                 Bitfield.Bit('parameter_version', 4, default=1),
+                 Bitfield.ReservedBit(4)),
+        Bitfield('parameter_valid', 1,
+                 Bitfield.Bit('boot_option_parameter_selector', 7),
+                 Bitfield.Bit('parameter_validity', 1)),
+        RemainingBytes('data'),
+    )
+
+@register_message_class
+class SetSystemBootOptionsReq(Message):
+    __cmdid__ = constants.CMDID_SET_SYSTEM_BOOT_OPTIONS
+    __netfn__ = constants.NETFN_CHASSIS
+    __fields__ = (
+        Bitfield('parameter_selector', 1,
+                 Bitfield.Bit('boot_option_parameter_selector', 7),
+                 Bitfield.Bit('parameter_validity', 1, default=0)),
+        RemainingBytes('data')
+    )
+
+@register_message_class
+class SetSystemBootOptionsRsp(Message):
+    __cmdid__ = constants.CMDID_SET_SYSTEM_BOOT_OPTIONS
+    __netfn__ = constants.NETFN_CHASSIS | 1
+    __fields__ = (
+        CompletionCode(),
     )

--- a/tests/msgs/test_chassis.py
+++ b/tests/msgs/test_chassis.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from array import array
 from nose.tools import eq_
 
 import pyipmi.msgs.chassis
@@ -52,3 +53,39 @@ def test_chassiscontrol_encode_valid_req():
     eq_(m.__netfn__, 0)
     eq_(m.__cmdid__, 2)
     eq_(data, b'\x01')
+
+
+def test_getsystembootoptions_encode_valid_req():
+    m = pyipmi.msgs.chassis.GetSystemBootOptionsReq()
+    m.parameter_selector.boot_option_parameter_selector = 5
+    data = encode_message(m)
+    eq_(m.__netfn__, 0)
+    eq_(m.__cmdid__, 9)
+    eq_(data, b'\x05\x00\x00')
+
+def test_getsystembootoptions_decode_valid_rsp():
+    m = pyipmi.msgs.chassis.GetSystemBootOptionsRsp()
+    decode_message(m, b'\x00\x01\x85\x00\x08\x00\x00\x00')
+
+    eq_(m.completion_code, 0x00)
+    eq_(m.parameter_version.parameter_version, 1)
+    eq_(m.parameter_valid.boot_option_parameter_selector, 5)
+    eq_(m.parameter_valid.parameter_validity, 1)
+    eq_(m.data, array('B', b'\x00\x08\x00\x00\x00'))
+
+def test_setsystembootoptions_encode_valid_req():
+    m = pyipmi.msgs.chassis.SetSystemBootOptionsReq()
+    m.parameter_selector.boot_option_parameter_selector = 5
+    m.parameter_selector.parameter_validity = 1
+    m.data = array('B', b'\x70\x08\x00\x00\x00')
+    data = encode_message(m)
+
+    eq_(m.__netfn__, 0)
+    eq_(m.__cmdid__, 8)
+    eq_(data, b'\x85\x70\x08\x00\x00\x00')
+
+def test_setsystembootoptions_decode_valid_rsp():
+    m = pyipmi.msgs.chassis.SetSystemBootOptionsRsp()
+    decode_message(m, b'\x00')
+
+    eq_(m.completion_code, 0x00)

--- a/tests/test_chassis.py
+++ b/tests/test_chassis.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from nose.tools import eq_, ok_
+from nose.tools import eq_, ok_, raises
+from array import array
 
-from pyipmi.chassis import ChassisStatus
+from pyipmi.chassis import (ChassisStatus, data_to_boot_device,
+                            data_to_boot_mode, data_to_boot_persistency,
+                            boot_options_to_data, BootDevice)
 import pyipmi.msgs.chassis
 from pyipmi.msgs import decode_message
 
@@ -31,3 +34,30 @@ def test_chassisstatus_object():
     ok_('front_panel_lockout', status.chassis_state)
     ok_('drive_fault', status.chassis_state)
     ok_('cooling_fault', status.chassis_state)
+
+def test_datatobootmode():
+    eq_(data_to_boot_mode(array('B', [0, 0, 0, 0, 0])), "legacy")
+    eq_(data_to_boot_mode(array('B', [0b10100000, 0, 0, 0, 0])), "efi")
+
+def test_datatobootpersistency():
+    ok_(data_to_boot_persistency(array('B', [0b11000000, 0, 0, 0, 0])))
+    ok_(not data_to_boot_persistency(array('B', [0b10000000, 0, 0, 0, 0])))
+
+def test_datatobootdevice():
+    eq_(data_to_boot_device(array('B', [0b11000000, 0b00001000, 0, 0, 0])), BootDevice.DEFAULT_HDD)
+    eq_(data_to_boot_device(array('B', [0b11000000, 0b00000100, 0, 0, 0])), BootDevice.PXE)
+
+def test_bootoptionstodata():
+    eq_(boot_options_to_data("bios setup", "efi", True).array, array('B', [0b11100000, 0b00011000, 0, 0, 0]))
+
+@raises(TypeError)
+def test_bootoptionstodata_raise_typeerror():
+    boot_options_to_data("pxe", "efi", 1)
+
+@raises(ValueError)
+def test_bootoptionstodata_raise_valueerror_bootmode():
+    boot_options_to_data("pxe", "wrong boot mode", True)
+
+@raises(ValueError)
+def test_bootoptionstodata_raise_valueerror_bootdevice():
+    boot_options_to_data("wrong boot device", "efi", True)

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from nose.tools import eq_, raises
+from array import array
+
+from pyipmi.lan import (data_to_ip_address, data_to_ip_source,
+                        data_to_mac_address, data_to_vlan, ip_address_to_data,
+                        ip_source_to_data, vlan_to_data)
+
+
+def test_datatoipaddress():
+    eq_(data_to_ip_address(array('B', [192, 168, 1, 1])), "192.168.1.1")
+
+def test_ipaddresstodata():
+    eq_(ip_address_to_data("192.168.1.1").array, array('B', [192, 168, 1, 1]))
+
+def test_datatoipsource():
+    eq_(data_to_ip_source(array('B', [0])), "unknown")
+    eq_(data_to_ip_source(array('B', [1])), "static")
+    eq_(data_to_ip_source(array('B', [2])), "dhcp")
+    eq_(data_to_ip_source(array('B', [3])), "bios")
+    eq_(data_to_ip_source(array('B', [4])), "other")
+
+def test_ipsourcetodata():
+    eq_(ip_source_to_data("static").array, array('B', [1]))
+    eq_(ip_source_to_data("dhcp").array, array('B', [2]))
+
+@raises(ValueError)
+def test_ipsourcetodata_raise_valueerror():
+    ip_source_to_data("does not exist")
+
+def test_datatomacaddress():
+    eq_(data_to_mac_address(array('B', [0xab, 0xcd, 0xef, 0x12, 0x34, 0x56])), "ab:cd:ef:12:34:56")
+
+def test_datatovlan():
+    eq_(data_to_vlan(array('B', [138, 129])), 394)
+    eq_(data_to_vlan(array('B', [0, 0])), 0)
+    eq_(data_to_vlan(array('B', [19, 128])), 19)
+
+def test_vlantodata():
+    eq_(vlan_to_data(394).array, array('B', [138, 129]))
+    eq_(vlan_to_data(0).array, array('B', [0, 0]))
+    eq_(vlan_to_data(19).array, array('B', [19, 128]))
+
+@raises(TypeError)
+def test_vlantodata_raise_typeerror():
+    vlan_to_data("wrong type of argument")
+
+@raises(ValueError)
+def test_vlantodata_raise_valueerror():
+    vlan_to_data(4096)


### PR DESCRIPTION
This pull request aims to add support for setting boot mode and boot device, and add some useful methods to abstract how to set VLAN ID, mac address, ip source and boot options without having to deal with bit manipulation.

- Add Get/Set SystemBootOptions request and response definitions in msgs/chassis.py
- Add helpers methods to easily manipulate lan parameters in lan.py
- Add helpers methods to easily manipulate boot options in chassis.py

I'm willing to contribute to this project so do not hesitate to tell me if I'm doing something wrong !