### PR TITLE
Fix set user access optional byte

### DIFF
--- a/pyipmi/messaging.py
+++ b/pyipmi/messaging.py
@@ -93,7 +93,7 @@ class Messaging(object):
         return UserAccess(rsp)
 
     def set_user_access(self, userid, ipmi_msg, link_auth, callback_only,
-                        priv_level, channel=0, enable_change=1):
+                        priv_level, channel=0, enable_change=1, user_session_limit=0):
         req = create_request_by_name('SetUserAccess')
         req.channel_access.channel_number = channel
         req.channel_access.ipmi_msg = ipmi_msg
@@ -103,6 +103,7 @@ class Messaging(object):
         req.userid.userid = userid
         req.privilege.privilege_level = CONVERT_USER_PRIVILEGE_TO_RAW.get(
             priv_level, 0x0F)
+        req.session_limit.simultaneous_session_limit = user_session_limit
         rsp = self.send_message(req)
         check_completion_code(rsp.completion_code)
 

--- a/pyipmi/msgs/device_messaging.py
+++ b/pyipmi/msgs/device_messaging.py
@@ -19,7 +19,6 @@ from . import register_message_class
 from . import Message
 from . import UnsignedInt
 from . import Bitfield
-from . import Optional
 from . import String
 from . import CompletionCode
 from . import RemainingBytes
@@ -504,11 +503,9 @@ class SetUserAccessReq(Message):
         Bitfield('privilege', 1,
                  Bitfield.Bit('privilege_level', 4, 0x0f),
                  Bitfield.ReservedBit(4, 0)),
-        Optional(
-            Bitfield('session_limit', 1,
-                     Bitfield.Bit('simultaneous_session_limit', 4, 1),
-                     Bitfield.ReservedBit(4, 0))
-        )
+        Bitfield('session_limit', 1,
+                 Bitfield.Bit('simultaneous_session_limit', 4, 0),
+                 Bitfield.ReservedBit(4, 0))
     )
 
 

--- a/tests/msgs/test_device_messaging.py
+++ b/tests/msgs/test_device_messaging.py
@@ -435,7 +435,7 @@ def test_set_user_access_req():
     data = encode_message(m)
     assert m.cmdid == 0x43
     assert m.netfn == 6
-    assert data == b'\x91\x02\x03'
+    assert data == b'\x91\x02\x03\x00'
 
 
 def test_user_access_rsp():


### PR DESCRIPTION
The `SetUserAccess` command has an Optional byte for "User Session Limit" (Section 22.26 of IPMI spec). This byte should be set to `0x00` by default and not `0x01` as it was here before (my mistake).

Moreover, when testing on a OCP Leopard BMC (from Quanta), the `SetUserAccess` command fail with an error code `Request data length invalid` because this byte was not present in the request payload. This PR adds the possibility to set the "User Session Limit" and make sure this byte is always present in the request.