### PR TITLE
interface/aardvark: add support for fastmode

### DIFF
--- a/pyipmi/interfaces/aardvark.py
+++ b/pyipmi/interfaces/aardvark.py
@@ -37,7 +37,8 @@ class Aardvark(object):
     NAME = 'aardvark'
 
     def __init__(self, slave_address=0x20, port=0, serial_number=None,
-                 enable_i2c_pullups=None, enable_target_power=None):
+                 enable_i2c_pullups=None, enable_target_power=None,
+                 enable_fastmode=None):
         if pyaardvark is None:
             raise RuntimeError('No pyaardvark module found. You can not '
                                'use this interface.')
@@ -55,11 +56,22 @@ class Aardvark(object):
         if enable_target_power:
             self.enable_target_power(enable_target_power)
 
+        if enable_fastmode is not None:
+            self.enable_fastmode(enable_fastmode)
+        else:
+            self.enable_fastmode(False)
+
     def enable_pullups(self, enabled):
         self._dev.i2c_pullups = enabled
 
     def enable_target_power(self, enabled):
         self._dev.target_power = enabled
+
+    def enable_fastmode(self, enabled):
+        if enabled:
+            self._dev.i2c_bitrate = 400
+        else:
+            self._dev.i2c_bitrate = 100
 
     def raw_write(self, address, data):
         self._dev.i2c_master_write(address, data)

--- a/pyipmi/ipmitool.py
+++ b/pyipmi/ipmitool.py
@@ -467,6 +467,7 @@ Aardvark interface options:
   serial=<SN>       Serial number of the device
   pullups=<on|off>  Enable/disable pullups
   power=<on|off>    Enable/disable target power
+  fastmode=<on|off> Enable/disable 400kHz I2C bitrate (Default 100kHz)
 
 Ipmitool interface options:
   interface_type    Set the interface type to be used (lan, lanplus, serial, open)
@@ -506,6 +507,10 @@ def parse_interface_options(interface_name, options):
                 interface_options['enable_target_power'] = True
             elif (name, value) == ('power', 'off'):
                 interface_options['enable_target_power'] = False
+            elif (name, value) == ('fastmode', 'on'):
+                interface_options['enable_fastmode'] = True
+            elif (name, value) == ('fastmode', 'off'):
+                interface_options['enable_fastmode'] = False
             else:
                 print('Warning: unknown option %s' % name)
         elif interface_name == 'ipmitool':


### PR DESCRIPTION
VITA introduces a feature to switch IPMB frequency from 100kHz to 400kHz. This is called fastmode. To support this with the aardvark interface switching the freqency is added.


Co-Developed-by: Michel Ferland <michel.ferland@kontron.com>