### PR TITLE
Add cmd error code descr

### DIFF
--- a/pyipmi/__init__.py
+++ b/pyipmi/__init__.py
@@ -37,7 +37,7 @@ from . import msgs
 from .errors import IpmiTimeoutError, CompletionCodeError, RetryError
 from .msgs.registry import create_request_by_name
 from .session import Session
-from .utils import check_completion_code, is_string
+from .utils import check_rsp_completion_code, is_string
 
 try:
     from version import __version__
@@ -210,7 +210,7 @@ class Ipmi(bmc.Bmc, chassis.Chassis, dcmi.Dcmi, fru.Fru, picmg.Picmg, hpm.Hpm,
             setattr(req, key, value)
 
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp
 
     def raw_command(self, lun, netfn, raw_bytes):

--- a/pyipmi/chassis.py
+++ b/pyipmi/chassis.py
@@ -19,7 +19,7 @@ from enum import Enum
 
 
 from .msgs import create_request_by_name
-from .utils import check_completion_code, ByteBuffer
+from .utils import check_completion_code, check_rsp_completion_code, ByteBuffer
 from .state import State
 
 from .msgs.chassis import \
@@ -178,7 +178,7 @@ class Chassis(object):
         req.set_selector = set_selector
         req.block_selector = block_selector
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp.data
 
     def set_system_boot_options(self, parameter_selector, data,
@@ -188,7 +188,7 @@ class Chassis(object):
         req.parameter_selector.boot_option_parameter_selector = parameter_selector
         req.data = data
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
 
     def get_boot_mode(self):
         """

--- a/pyipmi/errors.py
+++ b/pyipmi/errors.py
@@ -14,7 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
-from .msgs.constants import COMPLETION_CODE_DESCR
+from .msgs.constants import COMPLETION_CODE_DESCR, CC_ERR_CMD_SPECIFIC_DESC
 
 
 class DecodingError(Exception):
@@ -35,19 +35,26 @@ class IpmiTimeoutError(Exception):
 class CompletionCodeError(Exception):
     """IPMI completion code not OK."""
 
-    def __init__(self, cc, cmdid=None):
+    def __init__(self, cc, cmdid=None, netfn=None, group_extension=None):
         self.cc = cc
-        self.cc_desc = self.find_cc_desc(cc)
+        self.cc_desc = self.find_cc_desc(cc, cmdid, netfn, group_extension)
 
     def __str__(self):
         return "%s cc=0x%02x desc=%s" \
             % (self.__class__.__name__, self.cc, self.cc_desc)
 
     @staticmethod
-    def find_cc_desc(error_cc):
+    def find_cc_desc(error_cc, cmdid=None, netfn=None, group_extension=None):
+        # Search in global completion codes first
         for cc in COMPLETION_CODE_DESCR:
             if error_cc == cc[0]:
                 return cc[1]
+        # Then search in command specific completion codes
+        if cmdid is not None:
+            command_cc = CC_ERR_CMD_SPECIFIC_DESC.get((netfn, cmdid, group_extension), {})
+            descr = command_cc.get(error_cc, "Unknown error description")
+            return descr
+        # Completion code description not found
         return "Unknown error description"
 
 

--- a/pyipmi/interfaces/rmcp.py
+++ b/pyipmi/interfaces/rmcp.py
@@ -32,7 +32,8 @@ from ..logger import log
 from ..interfaces.ipmb import (IpmbHeaderReq, encode_ipmb_msg,
                                encode_bridged_message, decode_bridged_message,
                                rx_filter)
-from ..utils import check_completion_code, py3_array_tobytes
+from ..utils import (check_completion_code, check_rsp_completion_code,
+                     py3_array_tobytes)
 
 
 CLASS_NORMAL_MSG = 0x00
@@ -466,7 +467,7 @@ class Rmcp(object):
         if session._auth_username:
             req.user_name = session._auth_username.ljust(16, '\x00')
         rsp = self.send_and_receive(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp
 
     def _activate_session(self, session, challenge):
@@ -480,7 +481,7 @@ class Rmcp(object):
         req.session_id = self._session.sid
         req.initial_outbound_sequence_number = random.randrange(1, 0xffffffff)
         rsp = self.send_and_receive(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp
 
     def _set_session_privilege_level(self, level):
@@ -488,7 +489,7 @@ class Rmcp(object):
         req.target = self.host_target
         req.privilege_level.requested = level
         rsp = self.send_and_receive(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp
 
     def _get_device_id(self):

--- a/pyipmi/lan.py
+++ b/pyipmi/lan.py
@@ -15,7 +15,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
 from .msgs import create_request_by_name
-from .utils import check_completion_code, ByteBuffer
+from .utils import check_rsp_completion_code, ByteBuffer
 
 LAN_PARAMETER_SET_IN_PROGRESS = 0
 LAN_PARAMETER_AUTHENTICATION_TYPE_SUPPORT = 1
@@ -169,7 +169,7 @@ class Lan(object):
             req.set_selector = set_selector
             req.block_selector = block_selector
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
         return rsp.data
 
     def set_lan_config_param(self, channel,
@@ -179,7 +179,7 @@ class Lan(object):
         req.parameter_selector = parameter_selector
         req.data = data
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
 
     def get_ip_address(self, channel=0):
         """

--- a/pyipmi/messaging.py
+++ b/pyipmi/messaging.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 from .session import Session
 from .msgs import create_request_by_name
-from .utils import check_completion_code
+from .utils import check_completion_code, check_rsp_completion_code
 from .state import State
 
 
@@ -115,7 +115,7 @@ class Messaging(object):
         req.operation.operation = PasswordOperation.SET_PASSWORD
         req.password = password.ljust(16, '\x00')
         rsp = self.send_message(req)
-        check_completion_code(rsp.completion_code)
+        check_rsp_completion_code(rsp)
 
     def enable_user(self, userid):
         req = create_request_by_name('SetUserPassword')

--- a/pyipmi/msgs/constants.py
+++ b/pyipmi/msgs/constants.py
@@ -366,13 +366,15 @@ CMDID_SET_ASSET_TAG = 0x08
 CMDID_GET_MANAGEMENT_CONTROLLER_ID_STRING = 0x09
 CMDID_SET_MANAGEMENT_CONTROLLER_ID_STRING = 0x0a
 
-cc_err_cmd_specific_desc = {
-    CMDID_GET_SESSION_CHALLENGE: {
+# Command-specific completion codes. The key in this dictionary is a tuple
+# (NetFn, Command ID, Group extension).
+# The operation NetFn | 1 is here because it's the NetFn of an IPMI response.
+CC_ERR_CMD_SPECIFIC_DESC = {
+    (NETFN_APP, CMDID_GET_SESSION_CHALLENGE, None): {
         0x81: 'invalid user name',
         0x82: 'null user name (User 1) not enabled',
     },
-
-    CMDID_ACTIVATE_SESSION: {
+    (NETFN_APP, CMDID_ACTIVATE_SESSION, None): {
         0x81: 'No session slot available (BMC cannot accept any more'
               ' sessions)',
         0x82: 'No slot available for given user',
@@ -383,6 +385,48 @@ cc_err_cmd_specific_desc = {
         0x86: 'requested maximum privilege level exceeds user and/or channel'
               ' privilege limit',
     },
+    (NETFN_APP, CMDID_SET_SESSION_PRIVILEGE_LEVEL, None): {
+        0x80: "Requested level not available for this user",
+        0x81: "Requested level exceeds Channel and/or User Privilege Limit",
+        0x82: "Cannot disable User Level authentication",
+    },
+    (NETFN_APP, CMDID_SET_CHANNEL_ACCESS, None): {
+        0x82: "set not supported on selected channel (e.g. channel is session-"
+              "less.)",
+        0x83: "access mode not supported"
+    },
+    (NETFN_APP, CMDID_GET_CHANNEL_ACCESS, None): {
+        0x82: "Command not supported for selected channel (e.g. channel is"
+              "session-less.)"
+    },
+    (NETFN_APP, CMDID_SET_USER_PASSWORD, None): {
+        0x80: "password test failed. Password size correct, but"
+              "password data does not match stored value.",
+        0x81: "password test failed. Wrong password size was used."
+    },
+    (NETFN_TRANSPORT, CMDID_SET_LAN_CONFIGURATION_PARAMETERS, None): {
+        0x80: "parameter not supported.",
+        0x81: "attempt to set the 'set in progress' value (in parameter #0)"
+              "when not in the 'set complete' state. (This completion code"
+              "provides a way to recognize that another party has already"
+              "'claimed' the parameters)",
+        0x82: "attempt to write read-only parameter",
+        0x83: "attempt to read write-only parameter"
+    },
+    (NETFN_TRANSPORT, CMDID_GET_LAN_CONFIGURATION_PARAMETERS, None): {
+        0x80: "parameter not supported."
+    },
+    (NETFN_CHASSIS, CMDID_SET_SYSTEM_BOOT_OPTIONS, None): {
+        0x80: "parameter not supported.",
+        0x81: "attempt to set the 'set in progress' value (in parameter #0)"
+              "when not in the 'set complete' state. (This completion code"
+              "provides a way to recognize that another party has already"
+              "'claimed' the parameters)",
+        0x82: "attempt to write read-only parameter"
+    },
+    (NETFN_CHASSIS, CMDID_GET_SYSTEM_BOOT_OPTIONS, None): {
+        0x80: "parameter not supported:"
+    }
 }
 
 REPOSITORY_INITIATE_ERASE = 0xaa

--- a/pyipmi/utils.py
+++ b/pyipmi/utils.py
@@ -57,6 +57,25 @@ def check_completion_code(cc):
         raise CompletionCodeError(cc)
 
 
+def check_rsp_completion_code(rsp):
+    """
+    Check the completion code of a specific response and raise
+    CompletionCodeError in case there's an error.
+
+    This method allows to pass more metadata than the `check_completion_code`
+    method to try to interpret command-specific completion codes description in
+    case there is an error.
+
+    `rsp` should be a subclass of `Message` here.
+    """
+    if rsp.completion_code != constants.CC_OK:
+        raise CompletionCodeError(
+            rsp.completion_code,
+            cmdid=rsp.cmdid,
+            netfn=rsp.netfn & 0xfe,  # Get the request NetFn from response NetFn
+            group_extension=rsp.group_extension)
+
+
 def chunks(data, count):
     for i in range(0, len(data), count):
         yield data[i:i+count]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,11 @@ import pytest
 
 from array import array
 
-from pyipmi.utils import ByteBuffer, chunks
-from pyipmi.errors import DecodingError
+import pyipmi.msgs.device_messaging
+from pyipmi.utils import (ByteBuffer, chunks, check_completion_code,
+                          check_rsp_completion_code)
+from pyipmi.errors import DecodingError, CompletionCodeError
+from pyipmi.msgs import decode_message
 
 
 def test_bytebuffer_init_from_list():
@@ -118,3 +121,48 @@ def test_chunks():
         result.extend(chunk)
         assert len(chunk) == 2
     assert result == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+def test_check_completion_code_ok():
+    check_completion_code(0)
+
+
+def test_check_specific_completion_code_ok():
+    rsp = pyipmi.msgs.device_messaging.SetUserPasswordRsp()
+    decode_message(rsp, b'\x00')
+    check_rsp_completion_code(rsp)
+
+
+def test_check_completion_code_desc():
+    with pytest.raises(CompletionCodeError) as ex:
+        check_completion_code(0xc1)
+    assert ex.value.cc == 0xc1
+    assert ex.value.cc_desc == "Invalid Command"
+
+
+def test_check_completion_code_unknown_desc():
+    with pytest.raises(CompletionCodeError) as ex:
+        check_completion_code(0x81)
+    assert ex.value.cc == 0x81
+    assert ex.value.cc_desc == "Unknown error description"
+
+
+def test_check_rsp_completion_code_desc():
+    rsp = pyipmi.msgs.device_messaging.SetUserPasswordRsp()
+    decode_message(rsp, b'\x81')
+    with pytest.raises(CompletionCodeError) as ex:
+        check_rsp_completion_code(rsp)
+    assert rsp.cmdid == 71
+    assert rsp.netfn == 6 | 1
+    assert rsp.group_extension is None
+    assert ex.value.cc == 0x81
+    assert ex.value.cc_desc == "password test failed. Wrong password size was used."
+
+
+def test_check_rsp_completion_code_unknown_desc():
+    rsp = pyipmi.msgs.device_messaging.SetUserPasswordRsp()
+    decode_message(rsp, b'\x42')
+    with pytest.raises(CompletionCodeError) as ex:
+        check_rsp_completion_code(rsp)
+    assert ex.value.cc == 0x42
+    assert ex.value.cc_desc == "Unknown error description"


### PR DESCRIPTION
This PR aims to add some command-specific completion code descriptions.

Some descriptions were already written but never used, so I add the corresponding dictionary to the `CompletionCodeError` implementation. This dictionary also needs the corresponding command ID in order to find the description so I add a reference to the command ID in places where `check_completion_code` is called and where I'm sure the specific CC descriptions exist for this command.