### PR TITLE
lan: return vlan id = 0 if vlan is deactivated

### DIFF
--- a/pyipmi/lan.py
+++ b/pyipmi/lan.py
@@ -113,7 +113,14 @@ def data_to_vlan(data):
     """
     Convert a `GetLanConfigurationParameters(LAN_PARAMETER_802_1Q_VLAN_ID)` response
     data into an integer representation of the encoded vlan.
+
+    A disabled VLAN will return a VLAN ID = 0
     """
+    # Check if the vlan is enabled. We return vlan = 0 for a disabled vlan as a
+    # convention.
+    if data[1] >> 7 == 0:
+        return 0
+
     # The vlan ID must be extracted from the response, according to IPMI
     # specification.
     #

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -45,6 +45,12 @@ def test_datatovlan():
     assert data_to_vlan(array('B', [19, 128])) == 19
 
 
+def test_datatovlan_deactivated():
+    # Check if the data_to_vlan method returns 0 when a vlan data contains
+    # non-null vlan ID but the "vlan activate" bit is set to 0
+    assert data_to_vlan(array('B', [138, 1])) == 0
+
+
 def test_vlantodata():
     assert vlan_to_data(394).array == array('B', [138, 129])
     assert vlan_to_data(0).array == array('B', [0, 0])


### PR DESCRIPTION
There is a possibility where the BMC can have the vlan tagging option disabled, but it still has a vlan ID stored in its memory.
In that case, a call to `get_lan_config_param` to know the vlan ID will return the vlan ID of the BMC, but the caller will have no information about whether the vlan is actually enable or not.

To avoid this confusing behavior, I choose to return vlan ID = 0 as a "convention" when the vlan is disabled, but this can be debated obviously.