### PR TITLE
remove extraneous dependency on "future"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install python-coveralls coverage pytest pytest-cov future mock flake8
+        run: pip install python-coveralls coverage pytest pytest-cov mock flake8
 
         #      - name: Setup and run tests
         #        run: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,5 @@ setup(name=name,
           'mock',
       ],
       install_requires=[
-          'future',
       ],
       )


### PR DESCRIPTION
The `import __futur__` and `import future` are two different things, but easily mistaken.

The python3-future library is being now removed from Debian, which makes your software uninstallable.
Luckilly you don't _actually_ need it.

This PR clears it up.


Je vous rencontre bientôt à Bruxelles.