### PR TITLE
replace old "mock" by "unittest.mock" from the standard library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install python-coveralls coverage pytest pytest-cov mock flake8
+        run: pip install python-coveralls coverage pytest pytest-cov flake8
 
         #      - name: Setup and run tests
         #        run: python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(name=name,
       test_suite='tests',
       tests_require=[
           'pytest',
-          'mock',
       ],
       install_requires=[
       ],

--- a/tests/interfaces/test_ipmitool.py
+++ b/tests/interfaces/test_ipmitool.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from unittest.mock import MagicMock
+
 import pytest
-from mock import MagicMock
 
 from pyipmi.errors import IpmiTimeoutError, IpmiConnectionError
 from pyipmi.interfaces import Ipmitool

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from mock import MagicMock, call
+from unittest.mock import MagicMock, call
 
 from pyipmi.helper import clear_repository_helper
 from pyipmi.msgs.constants import (REPOSITORY_ERASURE_COMPLETED,

--- a/tests/test_hpm.py
+++ b/tests/test_hpm.py
@@ -17,7 +17,7 @@ from pyipmi.hpm import (ComponentProperty, ComponentPropertyDescriptionString,
                         PROPERTY_DEFERRED_VERSION)
 
 
-class TestComponentProperty(object):
+class TestComponentProperty:
     def test_general(self):
         prop = ComponentProperty().from_data(PROPERTY_GENERAL_PROPERTIES, b'\xaa')
         assert type(prop) is ComponentPropertyGeneral

--- a/tests/test_ipmi.py
+++ b/tests/test_ipmi.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from unittest.mock import MagicMock
+
 import pytest
-from mock import MagicMock
 
 from pyipmi import interfaces, create_connection, Target, Routing
 from pyipmi.errors import CompletionCodeError, RetryError

--- a/tests/test_ipmitool.py
+++ b/tests/test_ipmitool.py
@@ -3,7 +3,7 @@
 from pyipmi.ipmitool import parse_interface_options
 
 
-class TestParseInterfaceOptions(object):
+class TestParseInterfaceOptions:
     def test_options_aardvark(self):
         options = parse_interface_options('aardvark', 'serial=1234')
         assert options['serial_number'] == '1234'

--- a/tests/test_sel.py
+++ b/tests/test_sel.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from pyipmi import interfaces, create_connection
 from pyipmi.msgs.registry import create_response_by_name
 from pyipmi.sel import SelEntry, SelInfo
 
 
-class TestSel(object):
+class TestSel:
 
     def test_get_sel_entries(self):
         rsps = list()
@@ -36,7 +36,7 @@ class TestSel(object):
         assert len(entries) == 2
 
 
-class TestSelInfo(object):
+class TestSelInfo:
     rsp = create_response_by_name('GetSelInfo')
     rsp.version = 1
     rsp.entries = 1023
@@ -108,7 +108,7 @@ class TestSelInfo(object):
     assert 'overflow_flag' in info.operation_support
 
 
-class TestSelEnty(object):
+class TestSelEnty:
 
     def test_from_data(self):
         data = [0xff, 0x03, 0x02, 0xf7, 0x61, 0xef, 0x52, 0x7e,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from pyipmi import interfaces, create_connection
 from pyipmi.msgs.sensor import (SetSensorThresholdsRsp, GetSensorThresholdsRsp,
@@ -10,7 +10,7 @@ from pyipmi.sensor import (EVENT_READING_TYPE_SENSOR_SPECIFIC,
                            SENSOR_TYPE_MODULE_HOT_SWAP)
 
 
-class TestSensor(object):
+class TestSensor:
 
     def setup_method(self):
         self.mock_send_recv = MagicMock()


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.