### PR TITLE
Set rmcp session privilege level in session activation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ Example with lan interface:
 
     connection.session.set_session_type_rmcp('10.0.0.1', port=623)
     connection.session.set_auth_type_user('admin', 'admin')
+    connection.session.set_priv_level("ADMINISTRATOR")
     connection.session.establish()
 
     connection.get_device_id()
@@ -87,7 +88,7 @@ ipmitool command:
 
 .. code:: shell
 
-    ipmitool -I lan -H 10.0.0.1 -p 623 -U "admin" -P "admin" -t 0x82 -b 0 -l 0 raw 0x06 0x01
+    ipmitool -I lan -H 10.0.0.1 -p 623 -L "ADMINISTRATOR" -U "admin" -P "admin" -t 0x82 -b 0 -l 0 raw 0x06 0x01
 
 
 Example with serial interface:

--- a/examples/interface_rmcp.py
+++ b/examples/interface_rmcp.py
@@ -11,6 +11,7 @@ interface = pyipmi.interfaces.create_interface('rmcp',
 ipmi = pyipmi.create_connection(interface)
 ipmi.session.set_session_type_rmcp('10.0.114.199', 623)
 ipmi.session.set_auth_type_user('admin', 'admin')
+ipmi.session.set_priv_level("ADMINISTRATOR")
 ipmi.session.establish()
 ipmi.target = pyipmi.Target(ipmb_address=0x20)
 

--- a/pyipmi/interfaces/rmcp.py
+++ b/pyipmi/interfaces/rmcp.py
@@ -476,8 +476,7 @@ class Rmcp(object):
         req = create_request_by_name('ActivateSession')
         req.target = self.host_target
         req.authentication.type = session.auth_type
-        req.privilege_level.maximum_requested =\
-            Session.PRIV_LEVEL_ADMINISTRATOR
+        req.privilege_level.maximum_requested = session.priv_level
         req.challenge_string = challenge
         req.session_id = self._session.sid
         req.initial_outbound_sequence_number = random.randrange(1, 0xffffffff)


### PR DESCRIPTION
# The issue

After PR  #144 was merged, I tried to connect to a BMC using an "OPERATOR" user with interface "rmcp", but I kept getting error messages such as :
```
CompletionCodeError cc=0x86 desc=requested maximum privilege level exceeds user and/or channel privilege limit
```
It works perfectly with interface "ipmitool".

# The cause

I think this error comes from the `_activate_session` method in `pyipmi/interfaces/rmcp.py`, which uses a hardcoded `Session.PRIV_LEVEL_ADMINISTRATOR` by default. If the BMC user only has "OPERATOR" privilege for example, trying to establish a session with maximum privilege requested set to "ADMINISTRATOR" it will result in an "Insufficient privilege" IPMI error.

---

I have also added an example of `set_priv_level` usage in the README and in the examples/ folder to show how it is supposed to be used.