### PR TITLE
fix: add long password ipmi error

### DIFF
--- a/pyipmi/errors.py
+++ b/pyipmi/errors.py
@@ -90,3 +90,12 @@ class IpmiConnectionError(Exception):
 
     def __str__(self):
         return "{}".format(self.msg)
+
+
+class IpmiLongPasswordError(Exception):
+    """Password longer than 20 bytes."""
+    def __init__(self, msg=None):
+        self.msg = msg
+
+    def __str__(self):
+        return "{}".format(self.msg)

--- a/tests/interfaces/test_ipmitool.py
+++ b/tests/interfaces/test_ipmitool.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyipmi.errors import IpmiTimeoutError, IpmiConnectionError
+from pyipmi.errors import IpmiTimeoutError, IpmiConnectionError, IpmiLongPasswordError
 from pyipmi.interfaces import Ipmitool
 from pyipmi import Session, Target
 from pyipmi.utils import py3_array_tobytes
@@ -221,5 +221,11 @@ class TestIpmitool:
     def test_parse_output_connection_error_rmcp(self):
         test_str = b'Error: Unable to establish IPMI v1.5 / RMCP session'
         with pytest.raises(IpmiConnectionError):
+            cc, rsp = self._interface._parse_output(test_str)
+            assert rsp is None
+
+    def test_parse_long_password_error(self):
+        test_str = b'lanplus: password is longer than 20 bytes.'
+        with pytest.raises(IpmiLongPasswordError):
             cc, rsp = self._interface._parse_output(test_str)
             assert rsp is None


### PR DESCRIPTION
The given IPMI password can be longer than IPMI expect. In that case the _parse_output method in Ipmitool's will output the following error "invalid literal for int() with base 16: 'lanplus:'". While if we look at the line that was taken from IPMI we will see that its "lanplus: password is longer than 20 bytes.". So the issue is that there is no check for this error and the function skips it and tries to convert that string from a hex into an integer. I have added an execption, regex check and the match check.