### PR TITLE
specify authentication error

### DIFF
--- a/pyipmi/errors.py
+++ b/pyipmi/errors.py
@@ -99,3 +99,12 @@ class IpmiLongPasswordError(Exception):
 
     def __str__(self):
         return "{}".format(self.msg)
+
+
+class AuthenticationError(Exception):
+    """Authentication error."""
+    def __init__(self, msg=None):
+        self.msg = msg
+
+    def __str__(self):
+        return "{}".format(self.msg)


### PR DESCRIPTION
The `Error: Unable to establish IPMI v1.5 / RMCP session` error message is too ambiguous. It makes it hard to find the the source of problem. We had servers that used for BMC and Redfish API different credentials  and it was hard to detect the issue because of the error message, it didn't tell if IPMI was disabled, inactive or if the credentials are invalid. By adding the `-v` flag we can get more info about the source of problem. The `RAKP 2 HMAC is invalid` is mostly and almost for every vendor means that the provided password is invalid ([IBM](https://community.ibm.com/community/user/discussion/unable-to-establish-ipmi-v2-rmcp-session),  [Intel](https://www.dell.com/community/en/conversations/vnx/rakp-2-hmac-is-invalid-error-unable-to-establish-ipmi-v2-rmcp-session/647f744af4ccf8a8de21d60e), etc).